### PR TITLE
add friendly error feedbacks

### DIFF
--- a/functions/extract.fish
+++ b/functions/extract.fish
@@ -1,30 +1,34 @@
 function extract
-    if test -f $argv
-        switch $argv
-            case \*.rar
+    if count $argv > /dev/null
+        if test -f $argv
+            switch $argv
+                case \*.rar
                 unrar x $argv
-            case \*.zip
-                unzip $argv
-            case \*.tar.bz2
-                tar xvjf $argv
-            case \*.tar.gz
-                tar xvzf $argv
-            case \*.bz2
-                bunzip2 $argv
-            case \*.gz
-                gunzip $argv
-            case \*.tar
-                tar xvf $argv
-            case \*.tbz2
-                tar xvjf $argv
-            case \*.tgz
-                tar xvzf $argv
-            case \*.Z
-                uncompress $argv
-            case \*.7z
-                7z x $argv
+                case \*.zip
+                    unzip $argv
+                case \*.tar.bz2
+                    tar xvjf $argv
+                case \*.tar.gz
+                    tar xvzf $argv
+                case \*.bz2
+                    bunzip2 $argv
+                case \*.gz
+                    gunzip $argv
+                case \*.tar
+                    tar xvf $argv
+                case \*.tbz2
+                    tar xvjf $argv
+                case \*.tgz
+                    tar xvzf $argv
+                case \*.Z
+                    uncompress $argv
+                case \*.7z
+                    7z x $argv
+            end
+        else
+            echo "Could not extract this: $argv"
         end
     else
-        "Could not extract this"
+      echo "Usage: extract YOUR_AWESOME_COMPRESSED_FILE"
     end
 end


### PR DESCRIPTION
when I first type `extract` and ENTER, it gives me

```
switch: Expected exactly one argument, got 0

functions/extract.fish (line 4):         switch $argv
                                                ^
in function “extract”
    called on standard input

```

I thought the package was broken, but it's actually not...
I think we should have some friendly error messages..😀
